### PR TITLE
Add field subtitle to Note model

### DIFF
--- a/src/main/java/com/jorgeacetozi/notepad/note/domain/model/Note.java
+++ b/src/main/java/com/jorgeacetozi/notepad/note/domain/model/Note.java
@@ -9,22 +9,32 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 @Entity
 public class Note {
-	
+
 	@Id
-	@GeneratedValue(strategy=GenerationType.AUTO)
+	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Integer id;
+
 	@NotEmpty
 	private String title;
+
+	private String subtitle;
+
 	@NotEmpty
 	private String content;
-	
+
 	// Makes Hibernate happy
-	private Note () {
-		
+	private Note() {
+
 	}
-	
-	public Note (String title, String content) {
+
+	public Note(String title, String content) {
 		this.title = title;
+		this.content = content;
+	}
+
+	public Note(String title, String subtitle, String content) {
+		this.title = title;
+		this.subtitle = subtitle;
 		this.content = content;
 	}
 
@@ -34,6 +44,10 @@ public class Note {
 
 	public String getTitle() {
 		return title;
+	}
+
+	public String getSubtitle() {
+		return subtitle;
 	}
 
 	public String getContent() {
@@ -46,6 +60,7 @@ public class Note {
 
 	@Override
 	public String toString() {
-		return "Note [id=" + id + ", title=" + title + ", content=" + content + ", wordCount=" + this.getWordCount() + "]";
+		return "Note [id=" + id + ", title=" + title + ", subtitle=" + subtitle + ", content=" + content
+				+ ", wordCount=" + this.getWordCount() + "]";
 	}
 }

--- a/src/main/resources/db/migration/V2__add_note_subtitle_column.sql
+++ b/src/main/resources/db/migration/V2__add_note_subtitle_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE note ADD subtitle VARCHAR(100);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,6 @@
 note.yourNotes=Your Notes
 note.title=Title
+note.subtitle=Subtitle
 note.content=Content
 note.wordCount=Word Count
 note.newNote=New Note

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -13,6 +13,7 @@
 			<thead>
 				<tr>
 					<th th:text="#{note.title}">Title</th>
+					<th th:text="#{note.subtitle}">Subtitle</th>
 					<th th:text="#{note.content}">Content</th>
 					<th th:text="#{note.wordCount}">Word Count</th>
 				</tr>
@@ -21,6 +22,7 @@
 			<tbody>
 				<tr th:each="note : ${notes}">
 					<td th:text="${note.title}">Kubernetes</td>
+					<td th:text="${note.subtitle}">Orchestration Tool</td>
 					<td th:text="${note.content}">Best container orchestration
 						tool ever!</td>
 					<td th:text="${note.wordCount}">5</td>
@@ -48,6 +50,11 @@
 									class="form-control" id="newNoteTitle" />
 							</div>
 							<div class="form-group">
+								<label for="newNoteSubtitle" class="control-label"
+									th:text="#{note.subtitle}">Subtitle</label> <input type="text"
+									class="form-control" id="newNoteSubtitle" />
+							</div>
+							<div class="form-group">
 								<label for="newNoteContent" class="control-label"
 									th:text="#{note.content}">Content</label>
 								<textarea class="form-control" id="newNoteContent"></textarea>
@@ -71,11 +78,13 @@
 			var newNoteModal = $("#newNoteModal");
 			var btnCreateNewNote = $("#btnCreateNewNote");
 			var txtNewNoteTitle = $("#newNoteTitle");
+			var txtNewNoteSubtitle = $("#newNoteSubtitle");
 			var txtNewNoteContent = $("#newNoteContent");
 
 			function createNewNote() {
 				var newNote = {
 					'title' : txtNewNoteTitle.val(),
+					'subtitle' : txtNewNoteSubtitle.val(),
 					'content' : txtNewNoteContent.val()
 				};
 
@@ -89,12 +98,14 @@
 						var $tr = $("<tr />");
 
 						$("<td />").text(note.title).appendTo($tr);
+						$("<td />").text(note.subtitle).appendTo($tr);
 						$("<td />").text(note.content).appendTo($tr);
 						$("<td />").text(note.wordCount).appendTo($tr);
 
 						$tr.appendTo($tbody);
 						newNoteModal.modal('hide');
 						txtNewNoteTitle.val("");
+						txtNewNoteSubtitle.val("");
 						txtNewNoteContent.val("")
 						
 				        noty({

--- a/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/CreateNoteTest.java
+++ b/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/CreateNoteTest.java
@@ -43,14 +43,21 @@ public class CreateNoteTest {
 		newNotePage.create(newNote);
 		assertThat(newNotePage.getMessage(), equalTo(newNoteSuccessMessage));
 	}
-	
+
+	@Test
+	public void shouldCreateNewNoteWithTitleSubtitleAndContent() throws InterruptedException {
+		Note newNote = new Note("Acceptance Test", "Selenium Framework", "Creating note from the acceptance test");
+		newNotePage.create(newNote);
+		assertThat(newNotePage.getMessage(), equalTo(newNoteSuccessMessage));
+	}
+
 	@Test
 	public void shouldNotCreateNewNoteWhenTitleIsEmpty() throws InterruptedException {
 		Note newNote = new Note("", "Creating note from the acceptance test");
 		newNotePage.create(newNote);
 		assertThat(newNotePage.getMessage(), equalTo(newNoteFailMessage));
 	}
-	
+
 	@Test
 	public void shouldNotCreateNewNoteWhenContentIsEmpty() throws InterruptedException {
 		Note newNote = new Note("Acceptance Test", "");

--- a/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/pageObject/NewNotePage.java
+++ b/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/pageObject/NewNotePage.java
@@ -12,32 +12,38 @@ import com.jorgeacetozi.notepad.note.domain.model.Note;
 
 public class NewNotePage {
 
-	@FindBy(id="newNote")
+	@FindBy(id = "newNote")
 	private WebElement newNoteModal;
-	
-	@FindBy(id="newNoteTitle")
+
+	@FindBy(id = "newNoteTitle")
 	private WebElement title;
-	
-	@FindBy(id="newNoteContent")
+
+	@FindBy(id = "newNoteSubtitle")
+	private WebElement subtitle;
+
+	@FindBy(id = "newNoteContent")
 	private WebElement content;
-	
-	@FindBy(id="btnCreateNewNote")
+
+	@FindBy(id = "btnCreateNewNote")
 	private WebElement createNoteButton;
-	
+
 	private Long sleep = 2000l;
-	
+
 	private WebDriver driver;
-	
-    public NewNotePage(WebDriver driver) {
-    	this.driver = driver;
-        PageFactory.initElements(driver, this);
-    }
-	
+
+	public NewNotePage(WebDriver driver) {
+		this.driver = driver;
+		PageFactory.initElements(driver, this);
+	}
+
 	public void create(Note newNote) throws InterruptedException {
 		newNoteModal.click();
 		sleep(sleep);
-		
+
 		title.sendKeys(newNote.getTitle());
+		if (newNote.getSubtitle() != null) {
+			subtitle.sendKeys(newNote.getSubtitle());
+		}
 		content.sendKeys(newNote.getContent());
 		createNoteButton.click();
 		sleep(sleep);

--- a/src/test/java/com/jorgeacetozi/notepad/integrationTests/note/api/NoteControllerTest.java
+++ b/src/test/java/com/jorgeacetozi/notepad/integrationTests/note/api/NoteControllerTest.java
@@ -53,6 +53,21 @@ public class NoteControllerTest {
 	}
 
 	@Test
+	public void shouldCreateNoteWithTitleSubtitleAndContentAndReturnHttp201Created() throws Exception {
+		Note note = new Note("Integration Tests", "Slower Feedback than Unit Tests",
+				"Test the external integrations such as databases or web services.");
+
+		this.mockMvc
+				.perform(post("/notes").contentType(MediaType.APPLICATION_JSON)
+						.content(new ObjectMapper().writeValueAsString(note)))
+				.andDo(print()).andExpect(status().isCreated()).andExpect(jsonPath("$.id", is(notNullValue())))
+				.andExpect(jsonPath("$.title", is(note.getTitle())))
+				.andExpect(jsonPath("$.subtitle", is(note.getSubtitle())))
+				.andExpect(jsonPath("$.content", is(note.getContent())))
+				.andExpect(jsonPath("$.wordCount", is(note.getWordCount())));
+	}
+
+	@Test
 	public void shouldNotCreateNoteWhenTitleIsEmptyAndReturnHttp400BadRequest() throws Exception {
 		Note note = new Note("", "Test the external integrations such as databases or web services.");
 

--- a/src/test/java/com/jorgeacetozi/notepad/integrationTests/note/domain/service/NoteServiceTest.java
+++ b/src/test/java/com/jorgeacetozi/notepad/integrationTests/note/domain/service/NoteServiceTest.java
@@ -20,24 +20,32 @@ import com.jorgeacetozi.notepad.note.domain.service.NoteService;
 @SpringBootTest
 @ActiveProfiles("test")
 public class NoteServiceTest {
-	
+
 	@Autowired
 	private NoteService noteService;
-	
+
 	private Note note;
-	
+
 	@Before
 	public void setUp() {
 		note = new Note("Kubernetes", "Best container orchestration tool ever");
 	}
-	
+
 	@After
 	public void destroy() {
 		noteService.delete(note);
 	}
-	
+
 	@Test
 	public void shouldCreateNoteWithTitleAndContent() {
+		Note createdNote = noteService.create(note);
+		assertThat(createdNote.getId(), notNullValue());
+		assertThat(createdNote.getWordCount(), is(5));
+	}
+
+	@Test
+	public void shouldCreateNoteWithTitleSubtitleAndContent() {
+		note = new Note("Kubernetes", "Easy Container Orchestration", "Best container orchestration tool ever");
 		Note createdNote = noteService.create(note);
 		assertThat(createdNote.getId(), notNullValue());
 		assertThat(createdNote.getWordCount(), is(5));

--- a/src/test/java/com/jorgeacetozi/notepad/unitTests/note/domain/model/NoteTest.java
+++ b/src/test/java/com/jorgeacetozi/notepad/unitTests/note/domain/model/NoteTest.java
@@ -31,7 +31,14 @@ public class NoteTest {
 		Set<ConstraintViolation<Note>> constraintViolations = validator.validate(note);
 		assertThat(constraintViolations.size(), is(0));
 	}
-	
+
+	@Test
+	public void shouldNotRaiseViolationWhenTitleSubtitleAndContentAreFilled() {
+		Note note = new Note("Unit Tests", "JUnit Framekwork", "Unit tests provide fast feedback");
+		Set<ConstraintViolation<Note>> constraintViolations = validator.validate(note);
+		assertThat(constraintViolations.size(), is(0));
+	}
+
 	@Test
 	public void shouldRaiseViolationWhenTitleIsEmpty() {
 		Note note = new Note("", "Unit tests provide fast feedback");
@@ -45,13 +52,13 @@ public class NoteTest {
 		Set<ConstraintViolation<Note>> constraintViolations = validator.validate(note);
 		assertThat(constraintViolations.size(), is(1));
 	}
-	
+
 	@Test
 	public void shouldCountOneForContentWithSingleWord() {
 		Note note = new Note("Unit Tests", "Xuxa");
 		assertThat(note.getWordCount(), is(1));
 	}
-	
+
 	@Test
 	public void shouldCountWordsFromNoteContent() {
 		Note note = new Note("Unit Tests",


### PR DESCRIPTION
# Changelog
**Branch** : 'add-note-title'

- Add subtitle attribute to Note.java model class
- Create database migration adding the column subtitle to table note
- Create new automated tests to ensure that the field subtitle is optional
- Update the view to include the subtitle input

# Tests
- [x] Adding a note with title and content should work
- [x] Adding a note with title, subtitle and content should work
- [x] Any either combination should raise an error message